### PR TITLE
Check responseString when importing a wsdl for a WCF web Service

### DIFF
--- a/src/OWASPZAPDotNetAPI/OWASPZAPDotNetAPI/ClientApi.cs
+++ b/src/OWASPZAPDotNetAPI/OWASPZAPDotNetAPI/ClientApi.cs
@@ -192,15 +192,15 @@ namespace OWASPZAPDotNetAPI
             Uri requestUrl = PrepareZapRequest(this.format, component, operationType, operationName, parameters);
             string responseString = webClient.DownloadString(requestUrl);
             XmlDocument responseXmlDocument = new XmlDocument();
-            if ( !string.IsNullOrEmpty(responseString))
+            if ( string.IsNullOrEmpty(responseString) && operationName == "importUrl")
             {
-                responseXmlDocument.LoadXml(responseString);
-            }
-            else
-            {
-                var xmlstr= "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><error>EmptyResponse</error>";
+                var xmlstr = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><emptyRoot />";
 
                 responseXmlDocument.LoadXml(xmlstr);
+            }
+            else
+            {               
+                responseXmlDocument.LoadXml(responseString);
             }
 
             return responseXmlDocument;

--- a/src/OWASPZAPDotNetAPI/OWASPZAPDotNetAPI/ClientApi.cs
+++ b/src/OWASPZAPDotNetAPI/OWASPZAPDotNetAPI/ClientApi.cs
@@ -192,7 +192,17 @@ namespace OWASPZAPDotNetAPI
             Uri requestUrl = PrepareZapRequest(this.format, component, operationType, operationName, parameters);
             string responseString = webClient.DownloadString(requestUrl);
             XmlDocument responseXmlDocument = new XmlDocument();
-            responseXmlDocument.LoadXml(responseString);
+            if ( !string.IsNullOrEmpty(responseString))
+            {
+                responseXmlDocument.LoadXml(responseString);
+            }
+            else
+            {
+                var xmlstr= "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><error>EmptyResponse</error>";
+
+                responseXmlDocument.LoadXml(xmlstr);
+            }
+
             return responseXmlDocument;
         }
 

--- a/src/OWASPZAPDotNetAPI/OWASPZAPDotNetAPI/Generated/Soap.cs
+++ b/src/OWASPZAPDotNetAPI/OWASPZAPDotNetAPI/Generated/Soap.cs
@@ -60,8 +60,7 @@ namespace OWASPZAPDotNetAPI.Generated
 		{
 			Dictionary<string, string> parameters = null;
 			parameters = new Dictionary<string, string>();
-			parameters.Add("url", url);
-            parameters.Add("outputFormat", "JSON");
+			parameters.Add("url", url);            
             return api.CallApi("soap", "action", "importUrl", parameters);
 		}
 

--- a/src/OWASPZAPDotNetAPI/OWASPZAPDotNetAPI/Generated/Soap.cs
+++ b/src/OWASPZAPDotNetAPI/OWASPZAPDotNetAPI/Generated/Soap.cs
@@ -61,7 +61,8 @@ namespace OWASPZAPDotNetAPI.Generated
 			Dictionary<string, string> parameters = null;
 			parameters = new Dictionary<string, string>();
 			parameters.Add("url", url);
-			return api.CallApi("soap", "action", "importUrl", parameters);
+            parameters.Add("outputFormat", "JSON");
+            return api.CallApi("soap", "action", "importUrl", parameters);
 		}
 
 	}


### PR DESCRIPTION
Check the responseString  and send back and empty xml doc when importing a wsdl.
With out this check the  process does not load all the items in the wsdl.
